### PR TITLE
Fix failing fbr and fstash commands on zsh

### DIFF
--- a/fzf-extras.zsh
+++ b/fzf-extras.zsh
@@ -381,11 +381,9 @@ fstash() {
           --print-query \
           --expect=ctrl-d,ctrl-b
   )"; do
-    mapfile -t out <<< "$out"
-    q="${out[0]}"
-    k="${out[1]}"
-    sha="${out[-1]}"
-    sha="${sha%% *}"
+    q=$(head -1 <<< "$out")
+    k=$(head -2 <<< "$out" | tail -1)
+    sha=$(tail -1 <<< "$out" | cut -d' ' -f1)
     [[ -z "$sha" ]] && continue
     if [[ "$k" == 'ctrl-d' ]]; then
       git diff "$sha"

--- a/fzf-extras.zsh
+++ b/fzf-extras.zsh
@@ -242,11 +242,9 @@ fbr() {
       --format='%(refname:short)'
   )" || return
 
-  num_branches="$(echo $(wc -l <<< "$branches") | xargs echo -n)"
-
   branch="$(
     echo "$branches" \
-      | fzf-tmux -d "$((2 + $num_branches))" +m
+      | fzf-tmux +m
   )" || return
 
   target="$(


### PR DESCRIPTION
See: https://github.com/atweiden/fzf-extras/pull/13

Thanks a lot for working on this. I love zsh and even if I'm not very good in shell I would love to have more script on zsh.

I tried few functions in the PR and have comments

### `fbr`
I have issue using your `fbr`. Especially on this part
```sh
  branch="$(
    echo "$branches" \
      | fzf-tmux -d "$((2 + "$num_branches"))" +m
  )"
zsh: bad math expression: operand expected at `""'
```

I have a working version I use all the time that is similar but uglier https://github.com/benoittgt/dotfiles_osx/blob/master/.zshrc#L43-L49

My proposal instead of https://github.com/atweiden/fzf-extras/issues/12#issue-354748802 is to remove the branch number.

```diff
--- a/fzf-extras.zsh
+++ b/fzf-extras.zsh
@@ -242,11 +242,9 @@ fbr() {
       --format='%(refname:short)'
   )" || return

-  num_branches="$(echo $(wc -l <<< "$branches") | xargs echo -n)"
-
   branch="$(
     echo "$branches" \
-      | fzf-tmux -d "$((2 + $num_branches))" +m
+      | fzf-tmux +m
   )" || return
```

### `fstash`

On `fstash` when I type Enter I get:
```
fstash:15: command not found: mapfile
h is not a valid reference
```
So instead I use this version https://github.com/benoittgt/fzf-extras/commit/0b86b15f6f8783ce77e933dd4ee5065696074c33